### PR TITLE
Fellowship: correct "lady of Luthien" to "Lay of Lúthien"

### DIFF
--- a/1_Fellowship-of-the-Ring/release-034811/EnglishOnly.The.Lord.of.the.Rings.The.Fellowship.of.the.Ring.Extended.Editions.2001.1080p.BluRay.x264.srt
+++ b/1_Fellowship-of-the-Ring/release-034811/EnglishOnly.The.Lord.of.the.Rings.The.Fellowship.of.the.Ring.Extended.Editions.2001.1080p.BluRay.x264.srt
@@ -3191,7 +3191,7 @@ This woman you sing of.
 
 750
 01:08:23,840 --> 01:08:26,240
-'Tis the lady of Luthien.
+'Tis the Lay of Lúthien.
 
 751
 01:08:26,240 --> 01:08:31,440

--- a/1_Fellowship-of-the-Ring/release-034811/Full.The.Lord.of.the.Rings.The.Fellowship.of.the.Ring.2001.EXTENDED.MkvCage.ZoowlCZ.srt
+++ b/1_Fellowship-of-the-Ring/release-034811/Full.The.Lord.of.the.Rings.The.Fellowship.of.the.Ring.2001.EXTENDED.MkvCage.ZoowlCZ.srt
@@ -3366,7 +3366,7 @@ This woman you sing of.
 
 786
 01:08:23,840 --> 01:08:26,240
-'Tis the lady of Luthien.
+'Tis the Lay of Lúthien.
 
 787
 01:08:26,240 --> 01:08:31,440

--- a/1_Fellowship-of-the-Ring/release-034818/Full.The.Lord.of.the.Rings.The.Fellowship.of.the.Ring.2001.EXTENDED.MkvCage.ZoowlCZ.srt
+++ b/1_Fellowship-of-the-Ring/release-034818/Full.The.Lord.of.the.Rings.The.Fellowship.of.the.Ring.2001.EXTENDED.MkvCage.ZoowlCZ.srt
@@ -3366,7 +3366,7 @@ This woman you sing of.
 
 786
 01:08:23,840 --> 01:08:26,240
-'Tis the lady of Luthien.
+'Tis the Lay of Lúthien.
 
 787
 01:08:26,240 --> 01:08:31,440

--- a/1_Fellowship-of-the-Ring/release-two-dvds/DIsk1.Full.The.Lord.of.the.Rings.The.Fellowship.of.the.Ring.2001.EXTENDED.MkvCage.ZoowlCZ.srt
+++ b/1_Fellowship-of-the-Ring/release-two-dvds/DIsk1.Full.The.Lord.of.the.Rings.The.Fellowship.of.the.Ring.2001.EXTENDED.MkvCage.ZoowlCZ.srt
@@ -3366,7 +3366,7 @@ This woman you sing of.
 
 786
 01:08:21,657 --> 01:08:24,057
-'Tis the lady of Luthien.
+'Tis the Lay of Lúthien.
 
 787
 01:08:24,057 --> 01:08:29,257


### PR DESCRIPTION
This didn't sound quite right to me when watching through this weekend, I've always thought he referred to the Lay when watching previously. Having done some investigation to confirm:

* Lúthien Tinúviel is the name of the "woman [Aragorn sings] of", he wouldn't refer to her as "the lady of" herself
* Per Tolkien Gateway[0], he sings an excerpt from the Lay of Lúthien (albeit in Westron) at this point in the books
* Gwaith[1] shows the lyrics he was singing were closely translated from that passage into Sindarin for the movie

[0] https://tolkiengateway.net/wiki/Lay_of_Leithian
[1] https://elvish.org/gwaith/movie_soundtrack_fotr.htm#lay